### PR TITLE
[Fix] 초기 로그인 지역 설정 오류 해결

### DIFF
--- a/app/src/main/java/likelion/project/dongnation/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/likelion/project/dongnation/ui/login/LoginViewModel.kt
@@ -204,7 +204,7 @@ class LoginViewModel : ViewModel() {
 
     fun signInCredentialToUserGOOGLE(credential: SignInCredential){
         val userType = LOGIN_GOOGLE
-        val userId = credential.googleIdToken
+        val userId = credential.id
         val userDisplayName = credential.displayName
         val userEmail = credential.id
         if(userId != null && userDisplayName != null){


### PR DESCRIPTION
### 작업 내용
---

- 구글 원탭 로그인시 기존 유저 또한 지역 설정으로 연결되는 오류 해결