### PR TITLE
[Feat] 재능 기부 상세 화면과 채팅 화면 연결 및  채팅 화면 Toolbar 상대 이름 표시

### DIFF
--- a/app/src/main/java/likelion/project/dongnation/ui/chatting/ChattingFragment.kt
+++ b/app/src/main/java/likelion/project/dongnation/ui/chatting/ChattingFragment.kt
@@ -44,6 +44,7 @@ class ChattingFragment : Fragment() {
         chattingRoomUserIdCounterpart =
             arguments?.getString("chattingRoomUserIdCounterpart", "로딩중").toString()
         chattingRoom = ChattingRoom()
+        Log.d("chatting", chattingRoomUserIdCounterpart)
 
         initUI()
         observe()
@@ -93,7 +94,7 @@ class ChattingFragment : Fragment() {
 
     // 유저 채팅 생성
     private fun sendMessage(inputMessage: String){
-        chattingViewModel.sendMessage(LoginViewModel.loginUserInfo.userId, "user2Tmp", inputMessage, getDate())
+        chattingViewModel.sendMessage(LoginViewModel.loginUserInfo.userId, chattingRoomUserIdCounterpart, inputMessage, getDate())
 //        chattingViewModel.sendMessage("user2Tmp0918", LoginViewModel.loginUserInfo.userId, inputMessage, getDate())
         fragmentChattingBinding.editTextChattingMessage.run {
             setText("")

--- a/app/src/main/java/likelion/project/dongnation/ui/chatting/ChattingFragment.kt
+++ b/app/src/main/java/likelion/project/dongnation/ui/chatting/ChattingFragment.kt
@@ -42,7 +42,7 @@ class ChattingFragment : Fragment() {
         mainActivity = activity as MainActivity
 
         chattingRoomUserIdCounterpart =
-            arguments?.getString("chattingRoomUserIdCounterpart", "로딩중").toString()
+            arguments?.getString("chattingRoomUserIdCounterpart", "").toString()
         chattingRoom = ChattingRoom()
         Log.d("chatting", chattingRoomUserIdCounterpart)
 
@@ -59,7 +59,7 @@ class ChattingFragment : Fragment() {
                 setNavigationOnClickListener {
                     mainActivity.removeFragment("ChattingFragment")
                 }
-                title = chattingRoomUserIdCounterpart
+                chattingViewModel.getUser(chattingRoomUserIdCounterpart)
             }
 
             recyclerViewChatting.run{
@@ -89,6 +89,9 @@ class ChattingFragment : Fragment() {
                     }
                 }
             }
+        }
+        chattingViewModel.chattingRoomUserNameCounterpart.observe(viewLifecycleOwner){
+            fragmentChattingBinding.toolbarChatting.title = chattingViewModel.chattingRoomUserNameCounterpart.value
         }
     }
 

--- a/app/src/main/java/likelion/project/dongnation/ui/chatting/ChattingListFragment.kt
+++ b/app/src/main/java/likelion/project/dongnation/ui/chatting/ChattingListFragment.kt
@@ -59,6 +59,7 @@ class ChattingListFragment : Fragment() {
             fragmentChattingListBinding.run{
                 recyclerViewChattingList.run{
                     chattingList = chattingListViewModel.chattingList.value!!
+                    adapter?.notifyDataSetChanged()
                 }
             }
         }

--- a/app/src/main/java/likelion/project/dongnation/ui/chatting/ChattingListViewModel.kt
+++ b/app/src/main/java/likelion/project/dongnation/ui/chatting/ChattingListViewModel.kt
@@ -2,7 +2,8 @@ package likelion.project.dongnation.ui.chatting
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import kotlinx.coroutines.runBlocking
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.async
 import likelion.project.dongnation.model.ChattingRoom
 import likelion.project.dongnation.repository.ChattingRoomRepository
 import likelion.project.dongnation.ui.login.LoginViewModel
@@ -12,7 +13,7 @@ class ChattingListViewModel : ViewModel() {
     val chattingList = MutableLiveData<ArrayList<ChattingRoom>>()
 
     fun getChattingList(){
-        runBlocking {
+        viewModelScope.async {
             chattingList.value = ArrayList(chattingRoomRepository.getChattingRooms(LoginViewModel.loginUserInfo.copy()))
         }
     }

--- a/app/src/main/java/likelion/project/dongnation/ui/chatting/ChattingViewModel.kt
+++ b/app/src/main/java/likelion/project/dongnation/ui/chatting/ChattingViewModel.kt
@@ -11,11 +11,14 @@ import likelion.project.dongnation.model.ChattingRoom
 import likelion.project.dongnation.model.Message
 import likelion.project.dongnation.model.User
 import likelion.project.dongnation.repository.ChattingRoomRepository
+import likelion.project.dongnation.repository.UserRepository
 
 class ChattingViewModel : ViewModel() {
     private val chattingRoomRepository = ChattingRoomRepository()
+    private val userRepository = UserRepository()
     var sendingState = MutableLiveData<Int>()
     val chattingRoom = MutableLiveData<ChattingRoom>()
+    val chattingRoomUserNameCounterpart = MutableLiveData<String>()
 
     fun sendMessage(userId: String, userCounterpartId: String, content: String, date: String)
     = viewModelScope.launch{
@@ -40,6 +43,12 @@ class ChattingViewModel : ViewModel() {
             GET_MESSAGE_COMPLETE
         }
         sendingState.value = result.await()
+    }
+
+    fun getUser(userId: String){
+        viewModelScope.async {
+            chattingRoomUserNameCounterpart.value = userRepository.getUserForId(userId)?.userName
+        }
     }
 
     companion object {

--- a/app/src/main/java/likelion/project/dongnation/ui/donate/DonateInfoFragment.kt
+++ b/app/src/main/java/likelion/project/dongnation/ui/donate/DonateInfoFragment.kt
@@ -54,7 +54,11 @@ class DonateInfoFragment : Fragment() {
             }
 
             buttonDonateInfoChat.setOnClickListener {
-                mainActivity.replaceFragment("ChattingFragment", true, null)
+                val bundle = Bundle()
+                bundle.putString("chattingRoomUserIdCounterpart",
+                    viewModel.userLiveData.value?.userId
+                )
+                mainActivity.replaceFragment("ChattingFragment", true, bundle)
             }
 
             buttonDonateInfoDonation.setOnClickListener {


### PR DESCRIPTION
### 작업 내용
---

- 재능 기부 상세화면에서 채팅하기 버튼 터치시 채팅 화면 연결
- 채팅 화면 Toolbar에 상대 유저 이름 표시
- 채팅 목록의 ViewModel의 getChattingList 메서드의 동작방식을 runBlocking에서 async로 변경해 로딩 속도 증가